### PR TITLE
Removes temp files; need for hard-coded GPG passphrases

### DIFF
--- a/tokgen.sh
+++ b/tokgen.sh
@@ -1,24 +1,23 @@
-# Todo: Replace <some phrase 1> and <some phrase 2> with your passphrases.
+#!/usr/bin/env bash
 
-gpg --batch --output ~/.oathtool/tempk --passphrase <some phrase 1> --decrypt ~/.oathtool/key.gpg
-gpg --batch --output ~/.oathtool/tempq  --passphrase <some phrase 2> --decrypt ~/.oathtool/qrcode.gpg
+set -o errexit
+set -o nounset
 
-# Following should be adjusted for the token format expected in your auth. Here, the format is key+totp.
-echo "$(cat ~/.oathtool/tempk)$(oathtool --base32 --totp $(<~/.oathtool/tempq))"  > ~/.oathtool/tmp      
+echo "Enter your passphrase for key.gpg and qrcode.gpg"
+read -s PASSPHRASE
+echo
+
+KEY=$(gpg --batch --output - --passphrase ${PASSPHRASE} --decrypt ~/.oathtool/key.gpg)
+TOTP=$(gpg --batch --output - --passphrase ${PASSPHRASE} --decrypt ~/.oathtool/qrcode.gpg | oathtool --base32 --totp -)
 
 # For mac uncomment this, comment the linux block
-pbcopy < ~/.oathtool/tmp
+echo ${TOTP} | pbcopy
 echo "Token pbcopied. Hit enter to clear clipboard when it is pasted."
 read ip
 pbcopy < /dev/null
 
 # For linux, uncomment this, comment the mac block: pbcopy is a mac utility, other OSs will need to use cat and xclip
-# cat ~/.oathtool/tmp | xclip -selection clipboard
-# read ip
-# xclip -sel clip < /dev/null
-
-
-# Remove temp files
-rm -f ~/.oathtool/tempq
-rm -f ~/.oathtool/tempk
-rm -f ~/.oathtool/tmp
+#echo ${TOTP} | xclip -sel clipboard
+#echo "Token copied to clipboard; press enter to clear"
+#read ip
+#xclip -sel clip < /dev/null


### PR DESCRIPTION
This PR removes the use of temp files storing decoded GPG secrets and
prompts for GPG passphrases rather than hard-coding them.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
